### PR TITLE
Add redirection to closed page fixes #17

### DIFF
--- a/main.js
+++ b/main.js
@@ -275,6 +275,10 @@ function initExperiment(stimuli) {
 
 
 function main() {
+    // Make sure you've updated your key in globals.js
+    uil.setAccessKey(ACCESS_KEY);
+    uil.stopIfExperimentClosed(ACCESS_KEY);
+
     // Option 1: client side balancing:
     let stimuli = pickRandomList();
     initExperiment(stimuli);


### PR DESCRIPTION
This pull caches the accesKey of the experiment and redirect the participant to the closed page when the experiment is closed at the dataserver.