### PR TITLE
upload experiment data as soon as feedback screen is visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         <link href=https://web-experiments.lab.hum.uu.nl/jspsych/uil-utils/0.1/fonts.css rel="stylesheet" type="text/css"/>
 
         <!-- Uil OTS libraries -->
-        <script src="https://web-experiments.lab.hum.uu.nl/jspsych/uil-utils/0.1/jspsych-uil-utils.js"></script>
+        <script type="module" src="https://web-experiments.lab.hum.uu.nl/jspsych/uil-utils/1.0/jspsych-uil-utils-import.js"></script>
 
          <!-- Uil OTS organised  -->
         <script src="globals.js"></script>

--- a/main.js
+++ b/main.js
@@ -100,7 +100,17 @@ let feedback_screen = {
     preamble: FEEDBACK_PREAMBLE,
     questions: [
 	{prompt: FEEDBACK_PROMPT, rows: 5},
-    ]
+    ],
+    on_load: function() {
+        uil.saveJson(jsPsych.data.get().json(), ACCESS_KEY);
+    },
+    on_finish: function(data) {
+        let payload = {
+            feedback: data.response,
+            ...jsPsych.data.dataProperties // adds subject id and list info
+        }
+        uil.saveJson(JSON.stringify(payload), ACCESS_KEY);
+    }
 };
 
 let end_screen = {
@@ -113,9 +123,6 @@ let end_screen = {
             data.rt = Math.round(data.rt);
         }
     },
-    on_load : function() {
-        uil.saveData(ACCESS_KEY);
-    }
 };
 
 


### PR DESCRIPTION
Some context:
In https://github.com/UiL-OTS-labs/jspsych-lexical-decision/commit/d467c48c8f9c03d398e298c58d30a80ad72b9ece I've added a feedback screen to the end of the experiment. Ideally, this is something all our templates should have.
However I was worried participants might close the experiment without providing feedback, which means their data would be lost.

So in this PR I changed the feedback trial to immediately upload the experimental data, and use a separate request for the feedback data. AFAIK the datastore server doesn't mind having multiple data saved per participant (although I would like to add tests for that)
One issue I ran into, is that when running locally you wouldn't see the feedback screen at all, because `uil.saveJSON()` has the separate preview flow which (indirectly) terminates the experiment.

I'd be glad to hear any opinions or ideas